### PR TITLE
fix: Added bearer token to influxdb health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - INFLUXDB_TOKEN=${INFLUXDB_TOKEN}
       - INFLUXDB_ORG=${INFLUXDB_ORG}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8181/health" ]
+      test: [ "CMD", "curl", "-f", "-H", "Authorization: Bearer ${INFLUXDB_TOKEN}", "http://localhost:8181/health" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Release version of influxdb3-core requires valid bearer token for health check